### PR TITLE
Attachment original_filename is allowed to be null.

### DIFF
--- a/mailqueue/models.py
+++ b/mailqueue/models.py
@@ -143,7 +143,10 @@ class MailerMessage(models.Model):
 class Attachment(models.Model):
     file_attachment = models.FileField(storage=get_storage(), upload_to=upload_to,
                                        blank=True, null=True)
-    original_filename = models.CharField(default=None, max_length=250, blank=False)
+    # Note: for original_filename, null=True is defined only to simplify the migration to the new version of this 
+    # package, having legacy data set. original_filename is actually required when adding attachment to an email 
+    # (it is used in the _send method)
+    original_filename = models.CharField(default=None, max_length=250, blank=False, null=True)
     email = models.ForeignKey(MailerMessage, on_delete=models.CASCADE, blank=True, null=True)
 
     class Meta:


### PR DESCRIPTION
This change for the Attachment model corresponds to the manual change in the migration file:
https://github.com/zonnepanelendelen/django-mail-queue/commit/4c87530dd981eb893bbdc59c299d050fad38701d

Thus, now we can run `makemigrations` for mijnstroom and Django will not detect any changes.
We could also write a new migration which would fill `original_filename` for all the existing rows, but then we would need to have appropriate values for that. So, to save time, we just change the field of the model.