### PR TITLE
Support for S3 storage attachments

### DIFF
--- a/mailqueue/models.py
+++ b/mailqueue/models.py
@@ -125,12 +125,13 @@ class MailerMessage(models.Model):
 
             # Add any additional attachments
             for attachment in self.attachment_set.all():
-
-                # django-storages S3Boto3Storage compatibility
-                if attachment.file_attachment.file.__class__.__name__ == 'S3Boto3StorageFile':
-                    self._attach_s3_file(msg, attachment)
-                else:
-                    self._attach_regular_file(msg, attachment)
+                # Try different ways to read the file
+                try:
+                    self._attach_local_storage_file(msg, attachment)
+                except NotImplementedError:
+                    # For the case when storage backend doesn't support absolute paths.
+                    # Compatibility with S3Boto3Storage of django-storages.
+                    self._attach_remote_storage_file(msg, attachment)
             try:
                 msg.send()
                 self.sent = True
@@ -139,11 +140,11 @@ class MailerMessage(models.Model):
                 logger.error('Mail Queue Exception: {0}'.format(e))
             self.save()
 
-    def _attach_s3_file(self, msg, attachment):
+    def _attach_remote_storage_file(self, msg, attachment):
         content = attachment.file_attachment.read()
         msg.attach(attachment.original_filename, content, None)
 
-    def _attach_regular_file(self, msg, attachment):
+    def _attach_local_storage_file(self, msg, attachment):
         path = attachment.file_attachment.path
         if os.path.isfile(path):
             with open(path, 'rb') as f:


### PR DESCRIPTION
This error happens in production on attempt to send a queued email with an attachment:
`NotImplementedError("This backend doesn't support absolute paths.")`
https://sentry.io/organizations/zonnepanelendelen-bv/issues/1731708155

i.e. mail queue can't get absolute path of a file from S3.
In Mijnstroom we were not using S3, attachments were stored on local disk. So this was not relevant.

This PR has a change needed to support files uploaded to S3 or other remote storage.

To reproduce and fix this error, I had used real S3 bucket of the staging server.
