### PR TITLE
[ZPD-875] handling refused recipients errors

### DIFF
--- a/mailqueue/models.py
+++ b/mailqueue/models.py
@@ -137,7 +137,9 @@ class MailerMessage(models.Model):
                 self.sent = True
             except Exception as e:
                 self.do_not_send = True
+                self.save()
                 logger.error('Mail Queue Exception: {0}'.format(e))
+                raise  # To be handled in send_mail task.
             self.save()
 
     def _attach_remote_storage_file(self, msg, attachment):

--- a/mailqueue/tasks.py
+++ b/mailqueue/tasks.py
@@ -8,7 +8,18 @@ from .models import MailerMessage
 @shared_task(name="tasks.send_mail", default_retry_delay=5, max_retries=5)
 def send_mail(pk):
     message = MailerMessage.objects.get(pk=pk)
-    message._send()
+    try:
+        message._send()
+    except Exception as e:
+        # Assuming that Django project uses anymail.backends.postmark.EmailBackend
+        if e.__class__.__name__ == "AnymailRecipientsRefused":
+            # Postmark API had refused recipient's email address.
+            # Do not retry the task, in this case there's no need to hit API repeatedly.
+            # Do not report this to Sentry. Refused recipients are tracked in Postmark UI as suppressed.
+            return
+        else:
+            # On any other exception proceed further to retry.
+            pass
 
     # Retry when message is not sent
     if not message.sent:

--- a/mailqueue/tasks.py
+++ b/mailqueue/tasks.py
@@ -17,9 +17,6 @@ def send_mail(pk):
             # Do not retry the task, in this case there's no need to hit API repeatedly.
             # Do not report this to Sentry. Refused recipients are tracked in Postmark UI as suppressed.
             return
-        else:
-            # On any other exception proceed further to retry.
-            pass
 
     # Retry when message is not sent
     if not message.sent:


### PR DESCRIPTION
With this PR we will not be getting exceptions in Sentry when recipients email address is invalid or refused.  
These exceptions are reported repeatedly, for the same users, every time when we send batch emails (reports, newsletter, etc.).  
Thus we should reduce noise in Sentry. Example:
https://sentry.io/organizations/zonnepanelendelen-bv/issues/1723664534/events/542f1ccddca6458dba89994c59b632f9/